### PR TITLE
Mostly style/notation fixes and simplifying function interfaces for ode_plot_tools

### DIFF
--- a/Chp1/02-Slope-Fields.ipynb
+++ b/Chp1/02-Slope-Fields.ipynb
@@ -223,7 +223,7 @@
    "source": [
     "# Setup the differential equation\n",
     "\n",
-    "def diffeq(x, t):  # t is independent variable and x is dependent variable\n",
+    "def diffeq(t, x):  # t is independent variable and x is dependent variable\n",
     "    return 9.8 - (x / 5)  # enter the formula for dx/dt"
    ]
   },
@@ -309,7 +309,7 @@
     "\n",
     "# Setup the differential equation\n",
     "\n",
-    "def diffeq(x, t):  # x and t are dependent and independent variables\n",
+    "def diffeq(t, x):  # x and t are dependent and independent variables\n",
     "    return 4*t**2 - x**2  # formula for dx/dt = dy/dq"
    ]
   },
@@ -475,6 +475,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ea1aef1c-94ed-4908-8d4b-5efe87c09f00",
+   "metadata": {},
+   "source": [
+    "## Question for Adam: Do you want to import and use slope_field_ivp from ode_plot_tools?"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "1f99a601-c190-4e4b-9e65-b7a13cf14b66",
@@ -483,12 +491,12 @@
    "source": [
     "from ode_plot_tools import plot_sol\n",
     "\n",
-    "fig, ax = plt.subplots(1,1, num=5)\n",
+    "# fig, ax = plt.subplots(1,1, num=5)\n",
     "\n",
     "# enter initial condition\n",
     "x0 = 2\n",
     "\n",
-    "plot_sol(t, x, diffeq, x0, ax)"
+    "plot_sol(t, x, diffeq, x0)"
    ]
   },
   {
@@ -520,7 +528,7 @@
     "               color = color)  # sets the color of each arrow from user inputs\n",
     "    # new line of code\n",
     "    plt.plot(ts, xsol, '-', color = 'red')  # plot solution\n",
-    "    plt.show"
+    "    plt.show()"
    ]
   },
   {
@@ -531,7 +539,7 @@
    "outputs": [],
    "source": [
     "# plot solution with initial condition x(0) = 42\n",
-    "%matplotlib widget\n",
+    "%matplotlib inline\n",
     "# Setup the grid\n",
     "t = np.linspace(0,10,11)  # note the start_t value\n",
     "x = np.linspace(40,60,10)\n",
@@ -577,7 +585,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib widget\n",
+    "%matplotlib inline\n",
     "# plot solution with initial condition x(0) = 42\n",
     "\n",
     "# Setup the grid\n",
@@ -935,9 +943,10 @@
     "\n",
     "%reset -f out \n",
     "\n",
+    "# If running on Google Colab, then change next line to %matplotlib inline\n",
     "%matplotlib widget\n",
-    "# Setup the plot\n",
-    "fig, ax = plt.subplots(1,1, num=5)\n",
+    "# Setup the plot and axes outside of plot_sol to enable clearing widget functionality\n",
+    "fig, ax = plt.subplots(1,1, num=5)  \n",
     "\n",
     "interact_manual(oplot.plot_sol, \n",
     "            t = fixed(t),\n",
@@ -945,8 +954,8 @@
     "            diffeq = fixed(diffeq),\n",
     "            x0 = widgets.FloatText(\n",
     "                value=0, description='Initial Conditions $x_0$'),\n",
-    "            ax = fixed(ax),\n",
     "            npts = fixed(100),\n",
+    "            ax = fixed(ax),\n",
     "            clear = widgets.Checkbox(value=False, description='Clear Previous')\n",
     "               )"
    ]

--- a/Chp1/04-Eulers-Method.ipynb
+++ b/Chp1/04-Eulers-Method.ipynb
@@ -197,7 +197,7 @@
     "t = np.linspace(0, 7, 8)  # np.linspace(initial, end, number_values)\n",
     "x = np.linspace(-4, 15, 20)  # np.linspace(initial, end, number_values)\n",
     "# Setup the differential equation\n",
-    "diffeq = lambda x, t: 0.3 * x * (1 - x/10)  # Use T and X for ind and dep variables\n",
+    "diffeq = lambda t, x: 0.3 * x * (1 - x/10)  # Use T and X for ind and dep variables\n",
     "\n",
     "%reset -f out \n",
     "\n",

--- a/Chp1/04-Eulers-Method.ipynb
+++ b/Chp1/04-Eulers-Method.ipynb
@@ -75,7 +75,7 @@
     "x = np.linspace(-4, 15, 20)  # np.linspace(initial, end, number_values)\n",
     "\n",
     "# Setup the differential equation\n",
-    "def diffeq(x, t):\n",
+    "def diffeq(t, x):\n",
     "    return 0.3 * x * (1 - x/10) # Use t and x for ind and dep variables"
    ]
   },
@@ -201,20 +201,25 @@
     "\n",
     "%reset -f out \n",
     "\n",
+    "# If running on Google Colab, then change next line to %matplotlib inline\n",
     "%matplotlib widget\n",
+    "# Setup the plot and axes outside of plot_sol to enable clearing widget functionality\n",
+    "fig, ax = plt.subplots(1,1, num=5)  \n",
+    "\n",
     "interact_manual(oplot.plot_dt, \n",
     "            t = fixed(t),\n",
     "            x = fixed(x),\n",
     "            diffeq = fixed(diffeq),\n",
     "            dt = widgets.FloatSlider(\n",
     "                value=0.5, min=0.25, max = 4, step=0.01, description='Step Size $dt=$'),\n",
-    "            t0 = widgets.FloatText(\n",
+    "            t_0 = widgets.FloatText(\n",
     "                value=0, description='$t_0$'),\n",
-    "            x0 = widgets.FloatText(\n",
+    "            x_0 = widgets.FloatText(\n",
     "                value=13, description='$x_0$'),\n",
     "            nsteps = widgets.IntSlider(\n",
     "                value=1, min=1, max = 10, description='Number of Steps'),\n",
     "            npts = fixed(12),\n",
+    "            ax = fixed(ax),\n",
     "            clear = widgets.Checkbox(value=False, description='Clear Previous')\n",
     "               )"
    ]
@@ -520,10 +525,13 @@
     "            t = fixed(t),\n",
     "            x = fixed(x),\n",
     "            diffeq = fixed(diffeq),\n",
-    "            x0 = widgets.FloatText(\n",
+    "            t_0 = fixed(0),\n",
+    "            x_0 = widgets.FloatText(\n",
     "                value=0, description='Initial Conditions $x_0$'),\n",
     "            dt = widgets.FloatSlider(\n",
     "                value=0.5, min=0.1, max = 1.5, step=0.001, description='Step Size $dt=$'),\n",
+    "            n = widgets.IntSlider(\n",
+    "                value=1, min=1, max = 1000, description='Number of Steps'),\n",
     "            ax = fixed(ax),\n",
     "            clear = widgets.Checkbox(value=False, description='Clear Previous')\n",
     "               )"
@@ -549,7 +557,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -563,7 +571,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/Chp1/Plot-Tools-Tutorial.ipynb
+++ b/Chp1/Plot-Tools-Tutorial.ipynb
@@ -35,7 +35,7 @@
     "x = np.linspace(40,60,10)  # np.linspace(initial, end, number_values)\n",
     "\n",
     "# Setup the differential equation\n",
-    "def diffeq(x, t):\n",
+    "def diffeq(t, x):\n",
     "    return 9.8 - (x / 5) "
    ]
   },
@@ -111,16 +111,13 @@
     "x = np.linspace(40,60,10)  # np.linspace(initial, end, number_values)\n",
     "\n",
     "# Setup the differential equation\n",
-    "def diffeq(x, t):\n",
+    "def diffeq(t, x):\n",
     "    return 9.8 - (x / 5) \n",
     "\n",
     "t0 = 0\n",
     "x0 = 42\n",
     "dt = 2\n",
     "nsteps = 4\n",
-    "# Setup the differential equation\n",
-    "def diffeq(x, t):\n",
-    "    return 9.8 - (x / 5) \n",
     "\n",
     "plot_dt(t, x, diffeq, t0, x0, dt, nsteps)"
    ]
@@ -145,18 +142,18 @@
     "from ode_plot_tools import forward_euler\n",
     "\n",
     "# define f(t,y)=dy/dt=y+t\n",
-    "f = lambda t, y: y + t \n",
+    "f = lambda t, x: x + t \n",
     "\n",
     "# this information was given\n",
-    "start_t = 0  # start time\n",
-    "end_t = 1.5  # end time\n",
-    "y_0 = 4 # value of y when t=start_t\n",
+    "t_0 =0 # initial time\n",
+    "t_f = 1.5  # final time\n",
+    "x_0 = 4 # initial value of y when t=t_0\n",
     "\n",
     "# We can choose this\n",
     "n = 3 # number of steps, add 1 since start at t=0\n",
-    "Delta_t = (1.5-0)/n  # Step size\n",
+    "dt = (1.5-0)/n  # Step size\n",
     "\n",
-    "forward_euler(f, Delta_t, n, start_t, y_0)"
+    "forward_euler(f, dt, n, t_0, x_0)"
    ]
   },
   {
@@ -177,7 +174,8 @@
    "outputs": [],
    "source": [
     "from ode_plot_tools import plot_euler\n",
-    "def diffeq(x, t):\n",
+    "\n",
+    "def diffeq(t, x):\n",
     "    return 9.8 - (x / 5) \n",
     "\n",
     "fig, ax = plt.subplots(1,1, num=5)\n",

--- a/Chp1/Plot-Tools-Tutorial.ipynb
+++ b/Chp1/Plot-Tools-Tutorial.ipynb
@@ -79,13 +79,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Set up axis\n",
-    "fig, ax = plt.subplots(1,1, num=5)\n",
-    "\n",
     "# enter initial condition\n",
-    "x0 = 42\n",
+    "x_0 = 42\n",
     "\n",
-    "plot_sol(t, x, diffeq, x0, ax)"
+    "plot_sol(t, x, diffeq, x_0)"
    ]
   },
   {
@@ -106,6 +103,7 @@
    "outputs": [],
    "source": [
     "from ode_plot_tools import plot_dt\n",
+    "\n",
     "# Setup the grid\n",
     "t = np.linspace(0,10,11)  # np.linspace(initial, end, number_values)\n",
     "x = np.linspace(40,60,10)  # np.linspace(initial, end, number_values)\n",
@@ -114,12 +112,12 @@
     "def diffeq(t, x):\n",
     "    return 9.8 - (x / 5) \n",
     "\n",
-    "t0 = 0\n",
-    "x0 = 42\n",
+    "t_0 = 0\n",
+    "x_0 = 42\n",
     "dt = 2\n",
     "nsteps = 4\n",
     "\n",
-    "plot_dt(t, x, diffeq, t0, x0, dt, nsteps)"
+    "plot_dt(t, x, diffeq, t_0, x_0, dt, nsteps)"
    ]
   },
   {
@@ -145,7 +143,7 @@
     "f = lambda t, x: x + t \n",
     "\n",
     "# this information was given\n",
-    "t_0 =0 # initial time\n",
+    "t_0 = 0 # initial time\n",
     "t_f = 1.5  # final time\n",
     "x_0 = 4 # initial value of y when t=t_0\n",
     "\n",
@@ -178,14 +176,15 @@
     "def diffeq(t, x):\n",
     "    return 9.8 - (x / 5) \n",
     "\n",
-    "fig, ax = plt.subplots(1,1, num=5)\n",
-    "x0 = 10\n",
+    "t_0 = 1\n",
+    "x_0 = 10\n",
     "dt = 2\n",
+    "n = 3\n",
     "\n",
     "t = np.linspace(0,10, 11)\n",
     "x = np.linspace(0,50,10)  # np.linspace(initial, end, number_values)\n",
     "\n",
-    "plot_euler(t, x, diffeq, x0, dt, ax, clear=False)"
+    "plot_euler(t, x, diffeq, t_0, x_0, dt, n)"
    ]
   },
   {

--- a/Chp1/ode_plot_tools.py
+++ b/Chp1/ode_plot_tools.py
@@ -176,7 +176,7 @@ def plot_euler(t, x, diffeq, t_0, x_0, dt, n=None, ax=None, clear=False):
     # Plot approx
     if n is None:
         n = int(t[-1]/dt)
-    tt2 = np.linspace(t_0, t[-1], n+1)
+    tt2 = np.linspace(t_0, n*dt, n+1)
     ax.plot(tt2, forward_euler(diffeq, dt, n, t[0], x_0), ':', 
              marker='s')
     ax.set_ylim(ylim)

--- a/Chp1/ode_plot_tools.py
+++ b/Chp1/ode_plot_tools.py
@@ -14,7 +14,7 @@ def slope_field(t, x, diffeq,
                 **args):
     """Plots slope field given an ode
     
-    Given an ode of the form: dx/dt = f(x, t), plot a slope field (aka direction field) for given t and x arrays. 
+    Given an ode of the form: dx/dt = f(t, x), plot a slope field (aka direction field) for given t and x arrays. 
     Extra arguments are passed to matplotlib.pyplot.quiver
 
     Parameters
@@ -45,7 +45,7 @@ def slope_field(t, x, diffeq,
     if scale is not None:
         scale = 1/scale
     T, X = np.meshgrid(t, x)  # create rectangular grid with points
-    slopes = diffeq(X, T)
+    slopes = diffeq(T, X)
     dt = np.ones(slopes.shape)  # dt = an array of 1's with same dimension as diffeq
     dxu = slopes / np.sqrt(dt**2 + slopes**2)  # normalize dx
     dtu = dt / np.sqrt(dt**2 + slopes**2)  # normalize dt
@@ -60,10 +60,10 @@ def slope_field(t, x, diffeq,
     return ax
 
 
-def plot_sol(t, x, diffeq, x0, ax, npts=100, clear=False):
+def plot_sol(t, x, diffeq, x0, ax = None, npts=100, clear=False):
     """Plot Slope field and estimated solution given initial conidtion
     
-    Given an ode of the form: dx/dt = f(x, t), plot a slope field (aka direction field) for given t and x arrays. 
+    Given an ode of the form: dx/dt = f(t, x), plot a slope field (aka direction field) for given t and x arrays. 
     Given an initial condition x0, plot a solution line estimated with `odeint`.
     Extra arguments are passed to matplotlib.pyplot.quiver
 
@@ -80,7 +80,7 @@ def plot_sol(t, x, diffeq, x0, ax, npts=100, clear=False):
         The function f(t,x) = dx/dt
 
     x0 : float
-        Initial condition
+        Initial condition at t[0]
         
     ax : pyplot plotting axes
     
@@ -94,29 +94,32 @@ def plot_sol(t, x, diffeq, x0, ax, npts=100, clear=False):
         plotting axis with formatted quiver plot
     """
     
+    if (ax is None):
+        fig, ax = plt.subplots()
     if clear:
         ax.cla()
 
     slope_field(t, x, diffeq, color='grey', ax = ax)
     
-    # xlim = ax.get_xlim()
-    # ylim = ax.get_ylim()
-    
     # Plot solution
     tt = np.linspace(t.min(),t.max(),100)
-    sol = odeint(diffeq, x0, tt)
-    ax.plot(tt, sol)
+    sol = odeint(diffeq, x0, tt, tfirst=True)
+    
     xlim = ax.get_xlim()
     ylim = ax.get_ylim()
     
-    # ax.set_ylim(ylim)
-    # ax.set_xlim(xlim)
+    ax.plot(tt, sol)
+    
+    ax.set_xlim(xlim)
+    ax.set_ylim(ylim)
     
     plt.show()
+    return ax
     
     
 # Plot Slope field and solution given analytical solution
 def plot_dt(t, x, diffeq, t0, x0, dt, nsteps, npts=100, clear=False):
+    
     fig, ax = plt.subplots(1,1)
     if clear:
         ax.cla()
@@ -141,13 +144,13 @@ def plot_dt(t, x, diffeq, t0, x0, dt, nsteps, npts=100, clear=False):
     
 
 # Euler Methods
-def forward_euler(f, Delta_t, n, start_t, y_0):
-    # Assuming f is passed as a function of (y, t)
-    v = np.zeros(n+1)  # set each y_i by 0 at first
-    v[0] = y_0  # set first value to y_0
+def forward_euler(f, dt, n, start_t, x_0):
+    # Assuming f is passed as a function of (t, x)
+    v = np.zeros(n+1)  # set each x_i by 0 at first
+    v[0] = x_0  # set first value to x_0
     
     for i in range(0, n):
-        v[i+1] = v[i] + Delta_t * f(v[i], start_t + i*Delta_t)  # Euler's method formula
+        v[i+1] = v[i] + dt * f(start_t + i*dt, v[i])  # Euler's method formula
     return v
 
 
@@ -161,7 +164,7 @@ def plot_euler(t, x, diffeq, x0, dt, ax, clear=False):
 
     # Plot exact
     tt = np.linspace(t.min(),t.max(),100)
-    sol = odeint(diffeq, x0, tt)
+    sol = odeint(diffeq, x0, tt, tfirst=True)
     ax.plot(tt, sol)
     
     # Store limits to keep approx from changing

--- a/Chp1/ode_plot_tools.py
+++ b/Chp1/ode_plot_tools.py
@@ -60,11 +60,11 @@ def slope_field(t, x, diffeq,
     return ax
 
 
-def plot_sol(t, x, diffeq, x0, ax = None, npts=100, clear=False):
+def plot_sol(t, x, diffeq, x_0, ax = None, npts=100, clear=False):
     """Plot Slope field and estimated solution given initial conidtion
     
     Given an ode of the form: dx/dt = f(t, x), plot a slope field (aka direction field) for given t and x arrays. 
-    Given an initial condition x0, plot a solution line estimated with `odeint`.
+    Given an initial condition x_0, plot a solution line estimated with `odeint`.
     Extra arguments are passed to matplotlib.pyplot.quiver
 
     Parameters
@@ -79,7 +79,7 @@ def plot_sol(t, x, diffeq, x0, ax = None, npts=100, clear=False):
     diffeq : function
         The function f(t,x) = dx/dt
 
-    x0 : float
+    x_0 : float
         Initial condition at t[0]
         
     ax : pyplot plotting axes
@@ -103,7 +103,7 @@ def plot_sol(t, x, diffeq, x0, ax = None, npts=100, clear=False):
     
     # Plot solution
     tt = np.linspace(t.min(),t.max(),100)
-    sol = odeint(diffeq, x0, tt, tfirst=True)
+    sol = odeint(diffeq, x_0, tt, tfirst=True)
     
     xlim = ax.get_xlim()
     ylim = ax.get_ylim()
@@ -118,9 +118,10 @@ def plot_sol(t, x, diffeq, x0, ax = None, npts=100, clear=False):
     
     
 # Plot Slope field and solution given analytical solution
-def plot_dt(t, x, diffeq, t0, x0, dt, nsteps, npts=100, clear=False):
+def plot_dt(t, x, diffeq, t_0, x_0, dt, nsteps, ax=None, npts=100, clear=False):
     
-    fig, ax = plt.subplots(1,1)
+    if (ax is None):
+        fig, ax = plt.subplots()
     if clear:
         ax.cla()
     slope_field(t, x, diffeq, color='grey', ax = ax)
@@ -131,40 +132,41 @@ def plot_dt(t, x, diffeq, t0, x0, dt, nsteps, npts=100, clear=False):
     
     # Plot vector
     # scale=1/dt makes the vector 
-    tt = np.linspace(t0, t0+dt*(nsteps-1), nsteps)
-    xx = forward_euler(diffeq, dt, nsteps, t[0], x0)
+    tt = np.linspace(t_0, t_0+dt*(nsteps-1), nsteps)
+    xx = forward_euler(diffeq, dt, nsteps, t[0], x_0)
     
-    # slope_field(t0, x0, diffeq, scale=dt, ax = ax)  
     for i in range(0, nsteps):
         slope_field(tt[i], xx[i], diffeq, scale=dt, ax = ax)  
     
     ax.set_ylim(ylim)
     ax.set_xlim(xlim)
     plt.show()
-    
+    return ax
 
 # Euler Methods
-def forward_euler(f, dt, n, start_t, x_0):
+def forward_euler(f, dt, n, t_0, x_0):
     # Assuming f is passed as a function of (t, x)
     v = np.zeros(n+1)  # set each x_i by 0 at first
     v[0] = x_0  # set first value to x_0
     
     for i in range(0, n):
-        v[i+1] = v[i] + dt * f(start_t + i*dt, v[i])  # Euler's method formula
+        v[i+1] = v[i] + dt * f(t_0 + i*dt, v[i])  # Euler's method formula
     return v
 
 
 # Plot Slope field and solution given analytical solution
-def plot_euler(t, x, diffeq, x0, dt, ax, clear=False):
+def plot_euler(t, x, diffeq, t_0, x_0, dt, n=None, ax=None, clear=False):
     
+    if (ax is None):
+        fig, ax = plt.subplots()
     if clear:
         ax.cla()
 
     slope_field(t, x, diffeq, color='grey', ax = ax)
 
     # Plot exact
-    tt = np.linspace(t.min(),t.max(),100)
-    sol = odeint(diffeq, x0, tt, tfirst=True)
+    tt = np.linspace(t_0,t.max(),100)
+    sol = odeint(diffeq, x_0, tt, tfirst=True)
     ax.plot(tt, sol)
     
     # Store limits to keep approx from changing
@@ -172,10 +174,12 @@ def plot_euler(t, x, diffeq, x0, dt, ax, clear=False):
     ylim = ax.get_ylim()
     
     # Plot approx
-    n = int(t[-1]/dt)
-    tt2 = np.linspace(t[0], t[-1], n+1)
-    ax.plot(tt2, forward_euler(diffeq, dt, n, t[0], x0), ':', 
+    if n is None:
+        n = int(t[-1]/dt)
+    tt2 = np.linspace(t_0, t[-1], n+1)
+    ax.plot(tt2, forward_euler(diffeq, dt, n, t[0], x_0), ':', 
              marker='s')
     ax.set_ylim(ylim)
     ax.set_xlim(xlim)
     plt.show()
+    return ax


### PR DESCRIPTION
There is a question in there for Adam in the 02 worksheet. Some functions are written out in the code cells in the worksheet that are also in the ode_plot_tools. Not sure if you want to just import the functions from ode_plot_tools. I wrote a question in the actual notebook for you to review.

Most edits are stylistic/notational changes like making sure initial conditions were written with notation t_0 and x_0 for initial time and initial position/state variable and writing everything from the perspective of evaluation functions of (t,x) instead of (x,t).

The odeint in scipy assumes the diffeq is written as a function of (x,t) not (t,x), so we had to add a flag variable tfirst=True so that it knows we are writing things from the perspective of a function of (t,x) (so t is first...tfirst).